### PR TITLE
fix: compile on MacOS

### DIFF
--- a/src/algorithms/landr/count.h
+++ b/src/algorithms/landr/count.h
@@ -18,7 +18,7 @@ namespace streaming {
                 declareInput(_input, "input", "");
                 declareOutput(_output, 0, "output", "");
 
-                _vectorOutput = std::make_shared<VectorOutput<std::vector<Real>>>(&_accu);
+                _vectorOutput = std::make_shared<VectorOutput<std::vector<Real> > >(&_accu);
                 _input >> _vectorOutput->input("data");
             }
 
@@ -40,7 +40,7 @@ namespace streaming {
 
         private:
             std::shared_ptr<Algorithm> _vectorOutput;
-            std::vector<std::vector<Real>> _accu;
+            std::vector<std::vector<Real> > _accu;
 
     };
 

--- a/src/algorithms/landr/diagnostic.cpp
+++ b/src/algorithms/landr/diagnostic.cpp
@@ -17,7 +17,7 @@ namespace streaming {
         }
         
         // Grab frames from stream, as requested in constructor
-        const std::vector<std::vector<Real>>& frameInput = _frameInput.tokens();
+        const std::vector<std::vector<Real> >& frameInput = _frameInput.tokens();
         
         // Loop frames in stream
         for (int i = 0; i < frameInput.size(); ++i)

--- a/src/algorithms/landr/landrmfcc.cpp
+++ b/src/algorithms/landr/landrmfcc.cpp
@@ -19,8 +19,8 @@ namespace streaming {
         }
 
         // Grab frames from stream, as requested in constructor
-        const std::vector<std::vector<essentia::Real>>& spec = _magnitudeSpectrumInput.tokens();
-        std::vector<std::vector<essentia::Real>>& mfcc = _mfccOutput.tokens();
+        const std::vector<std::vector<essentia::Real> >& spec = _magnitudeSpectrumInput.tokens();
+        std::vector<std::vector<essentia::Real> >& mfcc = _mfccOutput.tokens();
         
         // Loop frames in stream
         for (int i = 0; i < spec.size() && i < mfcc.size(); ++i)

--- a/src/algorithms/landr/landrmfcc.h
+++ b/src/algorithms/landr/landrmfcc.h
@@ -49,8 +49,8 @@ namespace streaming {
             int _magnitudeSizeInSamples;
             double _sampleRate;
             
-            std::vector<std::vector<double>> _H;
-            std::vector<std::vector<double>> _T;
+            std::vector<std::vector<double> > _H;
+            std::vector<std::vector<double> > _T;
     };
 
 } // namespace streaming

--- a/src/algorithms/landr/linearregression.cpp
+++ b/src/algorithms/landr/linearregression.cpp
@@ -62,7 +62,7 @@ namespace streaming {
         }
         
         // Grab frames from stream, as requested in constructor
-        const std::vector<std::vector<Real>>& vecIn = _vectorInput.tokens();
+        const std::vector<std::vector<Real> >& vecIn = _vectorInput.tokens();
         std::vector<Real>& gradOut = _gradientOutput.tokens();
         std::vector<Real>& interOut = _intersectionOutput.tokens();
 

--- a/src/algorithms/landr/meanframes.cpp
+++ b/src/algorithms/landr/meanframes.cpp
@@ -16,8 +16,8 @@ namespace streaming {
             return NO_INPUT;
         }
 
-        const std::vector<std::vector<std::vector<Real>>>& frames = _input.tokens();
-        std::vector<std::vector<Real>>& means = _output.tokens();
+        const std::vector<std::vector<std::vector<Real> > >& frames = _input.tokens();
+        std::vector<std::vector<Real> >& means = _output.tokens();
 
         for (int i = 0; i < frames.size() && i < means.size(); ++i)
         {

--- a/src/algorithms/landr/meanframes.h
+++ b/src/algorithms/landr/meanframes.h
@@ -9,8 +9,8 @@ namespace streaming {
 
     class MeanFrames : public Algorithm {
         protected:
-            Sink<std::vector<std::vector<Real>>> _input;
-            Source<std::vector<Real>> _output;
+            Sink<std::vector<std::vector<Real> > > _input;
+            Source<std::vector<Real> > _output;
 
         public:
             MeanFrames() : Algorithm() {


### PR DESCRIPTION
- Added spaces to nested template declarations to avoid confusing the compiler with >> operator. - Removed bogus MS-DOS line endings