### PR TITLE
Fix memory leak in python streaming algorithm.

### DIFF
--- a/src/essentia/scheduler/network.cpp
+++ b/src/essentia/scheduler/network.cpp
@@ -31,7 +31,7 @@ namespace scheduler {
 
 // helper function, was inside Algorithm before but it makes more sense to have
 // it only here, statically defined (ie: not part of Algorithm API)
-set<Algorithm*> visibleDependencies(const Algorithm* algo) {
+set<Algorithm*> visibleDependencies(const Algorithm* algo, bool logWarnings=true) {
   set<Algorithm*> dependencies;
 
   // for each source of this algorithm...
@@ -45,7 +45,7 @@ set<Algorithm*> visibleDependencies(const Algorithm* algo) {
 
     vector<SinkBase*>& sinks = output->second->sinks();
 
-    if (!sinks.size()) {
+    if (!sinks.size() && logWarnings) {
       E_WARNING("Unconnected source (" << output->first << ") in " << algo->name());
     }
 
@@ -88,7 +88,14 @@ map<string, vector<Algorithm*> > mapVisibleDependencies(const Algorithm* algo) {
   return result;
 }
 
+void deleteNetwork(const streaming::Algorithm* algo) {
+  set<Algorithm*> dependencies = visibleDependencies(algo, false);
 
+  for (set<Algorithm*>::iterator it = dependencies.begin(); it != dependencies.end(); ++it) {
+    delete *it;
+  }
+  delete algo;
+}
 
 template <typename NodeType>
 vector<NodeType*> nodeDependencies(const Algorithm* algo) {

--- a/src/essentia/scheduler/network.h
+++ b/src/essentia/scheduler/network.h
@@ -267,6 +267,12 @@ class ESSENTIA_API Network {
 };
 
 /**
+* Delete the algorithm together with its all visible dependencies without 
+* creating a network object.
+*/
+void deleteNetwork(const streaming::Algorithm* algo);
+
+/**
  * Prints the fill state of all the buffers in the last created network.
  */
 void printNetworkBufferFillState();

--- a/src/python/pystreamingalgorithm.cpp
+++ b/src/python/pystreamingalgorithm.cpp
@@ -112,8 +112,9 @@ int PyStreamingAlgorithm::tp_init(PyStreamingAlgorithm *self, PyObject *args, Py
 // eventually deleted with the deleteNetwork function.
 void PyStreamingAlgorithm::tp_dealloc (PyObject* obj) {
   PyStreamingAlgorithm* self = reinterpret_cast<PyStreamingAlgorithm*>(obj);
-  // FIXME: need to deallocate something here I guess...
-  //if (self->isGenerator) streaming::deleteNetwork(self->algo);
+  if (self->isGenerator) {
+    scheduler::deleteNetwork(self->algo);
+  }
 
   self->ob_type->tp_free(obj);
 }


### PR DESCRIPTION
## Description
- Fix memory leak in python streaming algorithm.
- This fix unfortunately introduces a memory issue when using multiple FrameCutters / RhythmDetector (and possibly any algorithm that resizes the input stream) on the same audio stream. See https://github.com/MTG/essentia/issues/841 for more information on this issue. For this reason, we will need to review our usage of the aforementioned algorithms in LANDR.Analysis and ensure that we use a different audio loader for each of them as a workaround.

## Related Issue
https://mixgenius.atlassian.net/browse/MAS-1021