### PR TITLE
fix(MAS-2289): audio loader crash

### DIFF
--- a/src/algorithms/io/audioloader.cpp
+++ b/src/algorithms/io/audioloader.cpp
@@ -103,6 +103,8 @@ void AudioLoader::openAudioFile(const string& filename) {
     _audioCodec = avcodec_find_decoder(_audioCtx->codec_id);
 
     if (!_audioCodec) {
+        avformat_close_input(&_demuxCtx);
+        _demuxCtx = 0;
         throw EssentiaException("AudioLoader: Unsupported codec!");
     }
 


### PR DESCRIPTION
## Description
* Fix a crash in `AudioLoader::closeAudioFile` that occurred after calling `AudioLoader::openAudioFile` with an audio file that makes it throw an invalid codec exception. The demux context was not cleanup up properly in that case.

## Related Issue
https://mixgenius.atlassian.net/browse/MAS-2289